### PR TITLE
Multiple fixes to address tracebacks when copying local files to Azure

### DIFF
--- a/tests/test_oss.py
+++ b/tests/test_oss.py
@@ -170,7 +170,7 @@ def test_oss_raw_io():
             self.is_truncated = False
             self.next_marker = ''
             self.buckets = [oss2.models.SimplifiedBucketInfo(
-                bucket, 'location', int(m_time))]
+                bucket, 'location', int(m_time), 'extranet_endpoint', 'intranet_endpoint', 'storage_class')]
 
     class ListObjectsResult:
         """Dummy oss2.models.ListObjectsResult"""
@@ -242,7 +242,7 @@ def test_oss_raw_io():
 
         # Tests _list_locators
         assert list(oss_system._list_locators()) == [
-            (bucket, dict(location='location', creation_date=int(m_time)))]
+            (bucket, dict(location='location', creation_date=int(m_time),  extranet_endpoint='extranet_endpoint', intranet_endpoint='intranet_endpoint', storage_class='storage_class'))]
 
         # Tests _list_objects
         assert list(oss_system._list_objects(


### PR DESCRIPTION
Test case was a shutil-style copy of a local path to Azure.
- Fixes out-of-range block ID generation (#4)
- Fixes loading of block-blob client in buffered I/O class (#3)
- Fixes detection of block type using HEAD request (#2)